### PR TITLE
Fixed:  Blank page if no user found #45 

### DIFF
--- a/src/component/Profile/profilePage.css
+++ b/src/component/Profile/profilePage.css
@@ -1146,3 +1146,8 @@ font-size: 0.9rem;
         width: 78vw;
     }
 }
+
+.not-found{
+    color: rgb(71, 200, 122, 0.9);
+    text-align: center;
+}

--- a/src/component/Profile/profilePage.css
+++ b/src/component/Profile/profilePage.css
@@ -1147,6 +1147,8 @@ font-size: 0.9rem;
     }
 }
 
+
+/* Used to display user not found message */
 .not-found{
     color: rgb(71, 200, 122, 0.9);
     text-align: center;

--- a/src/component/Profile/profilePage.jsx
+++ b/src/component/Profile/profilePage.jsx
@@ -63,6 +63,7 @@ function ProfilePage() {
   }, [ifedit]);
 
   useEffect(() => {
+    console.log(profile)
     if (accessProfile) {
       setFollower(profile.followers.length);
       setFollowing(profile.following.length);
@@ -181,6 +182,16 @@ function ProfilePage() {
 
     return formattedDate;
   }
+
+  if(Object.keys(profile).length === 0) return (
+    <>
+    <Sidebar />
+    <div className="PROFILE POPUPBG">
+    <h1>User @{apiname} not found :(</h1>
+    </div>
+    </>
+    )
+  
 
   return (
     <>

--- a/src/component/Profile/profilePage.jsx
+++ b/src/component/Profile/profilePage.jsx
@@ -63,7 +63,7 @@ function ProfilePage() {
   }, [ifedit]);
 
   useEffect(() => {
-    console.log(profile)
+    console.log(profile, accessProfile)
     if (accessProfile) {
       setFollower(profile.followers.length);
       setFollowing(profile.following.length);
@@ -83,7 +83,7 @@ function ProfilePage() {
 
   useEffect(() => {
     // When the component mounts, call showTweets to display the tweets
-    showTweets();
+   if(accessProfile) showTweets();
     dispatch(ProfileAction(apiname));
   }, [apiname]);
 
@@ -183,10 +183,10 @@ function ProfilePage() {
     return formattedDate;
   }
 
-  if(Object.keys(profile).length === 0) return (
+  if(!accessProfile) return (
     <>
     <Sidebar />
-    <div className="PROFILE POPUPBG">
+    <div className="PROFILE">
     <h1>User @{apiname} not found :(</h1>
     </div>
     </>

--- a/src/component/Profile/profilePage.jsx
+++ b/src/component/Profile/profilePage.jsx
@@ -82,6 +82,8 @@ function ProfilePage() {
 
   useEffect(() => {
     // When the component mounts, call showTweets to display the tweets
+
+    //ensuring that tweets arent shown when the user doesnt exist(could lead to errors and hence the if condition)
    if(accessProfile) showTweets();
     dispatch(ProfileAction(apiname));
   }, [apiname]);
@@ -182,6 +184,7 @@ function ProfilePage() {
     return formattedDate;
   }
 
+  /* Used to display user not found message */
   if(!accessProfile) return (
     <>
     <Sidebar />

--- a/src/component/Profile/profilePage.jsx
+++ b/src/component/Profile/profilePage.jsx
@@ -63,7 +63,6 @@ function ProfilePage() {
   }, [ifedit]);
 
   useEffect(() => {
-    console.log(profile, accessProfile)
     if (accessProfile) {
       setFollower(profile.followers.length);
       setFollowing(profile.following.length);
@@ -186,16 +185,16 @@ function ProfilePage() {
   if(!accessProfile) return (
     <>
     <Sidebar />
-    <div className="PROFILE POPUPBG">
+          {loading === true ? <Loader loading={loading} /> : <div className="PROFILE POPUPBG">
         <div className="profileDiv1">
             <img src={avatar} className="pImage" alt="Avatar" />
           <div className="PBLOCK1">
             <div className="pBlock1">
-              User @{apiname} not found ☹️
+             <h3 className="not-found">User @{apiname} not found ☹️</h3>
             </div>
             </div>
           </div>
-          </div>
+          </div>}
     </>
     )
   

--- a/src/component/Profile/profilePage.jsx
+++ b/src/component/Profile/profilePage.jsx
@@ -186,9 +186,16 @@ function ProfilePage() {
   if(!accessProfile) return (
     <>
     <Sidebar />
-    <div className="PROFILE">
-    <h1>User @{apiname} not found :(</h1>
-    </div>
+    <div className="PROFILE POPUPBG">
+        <div className="profileDiv1">
+            <img src={avatar} className="pImage" alt="Avatar" />
+          <div className="PBLOCK1">
+            <div className="pBlock1">
+              User @{apiname} not found ☹️
+            </div>
+            </div>
+          </div>
+          </div>
     </>
     )
   


### PR DESCRIPTION
![image](https://github.com/Tweeter-Org/tweeter-frontend/assets/90673701/09b98649-40b9-4389-8ec1-9635a9f3bb20)

I've solved the [issuue](https://github.com/Tweeter-Org/tweeter-frontend/issues/45), by returning a user not found message if the boolean value accessProfile is false. I'm also ensuring that the user not found message isn't displayed until loading is completed. Please look into it and let me know if any changes are to be made. 

Regards,
Hisham.